### PR TITLE
[BUGFIX] Collect assets before render

### DIFF
--- a/Classes/AssetCollector.php
+++ b/Classes/AssetCollector.php
@@ -83,7 +83,7 @@ class AssetCollector implements SingletonInterface
         ];
     }
 
-    public function addJavaScriptFile(string $fileName, array $tagAttributes = null): void
+    public function addJavaScriptFile(string $fileName, array $additionalAttributes = null): void
     {
         // Only add JS file if not added already.
         foreach ($this->jsFiles as $jsFile) {
@@ -93,7 +93,7 @@ class AssetCollector implements SingletonInterface
         }
         $this->jsFiles[] = [
             'fileName' => $fileName,
-            'tagAttributes' => $tagAttributes
+            'additionalAttributes' => $additionalAttributes
         ];
     }
 

--- a/Classes/Hooks/AssetRenderer.php
+++ b/Classes/Hooks/AssetRenderer.php
@@ -31,7 +31,9 @@ class AssetRenderer implements SingletonInterface
      */
     public function insertAssets($params, PageRenderer $pageRenderer): void
     {
-        if ($this->getTypoScriptFrontendController() instanceof TypoScriptFrontendController) {
+        $typoScriptFrontendController = $this->getTypoScriptFrontendController();
+        if ($typoScriptFrontendController instanceof TypoScriptFrontendController) {
+            $this->collectInlineAssets($params, $typoScriptFrontendController);
             $assetCollector = GeneralUtility::makeInstance(AssetCollector::class);
             $cached = $this->getTypoScriptFrontendController()->config['b13/assetcollector'];
             if (!empty($cached['cssFiles']) && is_array($cached['cssFiles'])) {
@@ -53,7 +55,7 @@ class AssetRenderer implements SingletonInterface
     }
 
     /**
-     * Called via contentPostProc-all - this means, this is run at any time, even when "fully cached" or
+     * Called via insertAssets() - this means, this is run at any time, even when "fully cached" or
      * with USER_INT* objects on it.
      *
      * At this point, we're re-evaluating all included files from the cached information plus adding

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -3,5 +3,6 @@ if (!defined('TYPO3_MODE')) {
     die('Access denied.');
 }
 
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['contentPostProc-all']['b13/assetcollector'] = \B13\Assetcollector\Hooks\AssetRenderer::class . '->collectInlineAssets';
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_pagerenderer.php']['render-preProcess']['b13/assetcollector'] = \B13\Assetcollector\Hooks\AssetRenderer::class . '->collectCssFiles';
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_pagerenderer.php']['render-postProcess']['b13/assetcollector'] = \B13\Assetcollector\Hooks\AssetRenderer::class . '->insertAssets';

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -3,6 +3,5 @@ if (!defined('TYPO3_MODE')) {
     die('Access denied.');
 }
 
-$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['contentPostProc-all']['b13/assetcollector'] = \B13\Assetcollector\Hooks\AssetRenderer::class . '->collectInlineAssets';
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_pagerenderer.php']['render-preProcess']['b13/assetcollector'] = \B13\Assetcollector\Hooks\AssetRenderer::class . '->collectCssFiles';
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_pagerenderer.php']['render-postProcess']['b13/assetcollector'] = \B13\Assetcollector\Hooks\AssetRenderer::class . '->insertAssets';


### PR DESCRIPTION
This patch removes the contentPostProc-all hook and calls
the collector method directly before rendering the assets.
Additionally, a naming issue was solved and streamlined.
The naming of tagAttributes has changed to additionalAttributes.