### PR TITLE
[TASK] Don’t add empty viewBox attribute

### DIFF
--- a/Classes/AssetCollector.php
+++ b/Classes/AssetCollector.php
@@ -203,6 +203,7 @@ class AssetCollector implements SingletonInterface
                 $xmlContent->loadXML(file_get_contents($xmlFile));
 
                 $viewBox = $xmlContent->getElementsByTagName('svg')->item(0)->getAttribute('viewBox');
+                $viewBoxAttribute = $viewBox ? ' viewBox = "' . $viewBox . '"' : '';
 
                 $children = $xmlContent->getElementsByTagName('svg')->item(0);
 
@@ -210,7 +211,7 @@ class AssetCollector implements SingletonInterface
                     $svgInline .= trim((string)($child->ownerDocument->saveHtml($child)));
                 }
 
-                $inlineXml .= '<symbol id="icon-' . $iconIdentifier . '" viewBox="' . $viewBox . '">'
+                $inlineXml .= '<symbol id="icon-' . $iconIdentifier . '"' . $viewBoxAttribute . '>'
                               . $svgInline
                               . '</symbol>';
 


### PR DESCRIPTION
The empty attribute produces errors in some browsers. Since viewBox is not required it can be omitted.

![image](https://user-images.githubusercontent.com/14198734/117770653-78862480-b235-11eb-870c-63eef6226104.png)
