### PR TITLE
[TASK] resolve relative Paths in CSS

### DIFF
--- a/Classes/ViewHelpers/SvgViewHelper.php
+++ b/Classes/ViewHelpers/SvgViewHelper.php
@@ -28,6 +28,7 @@ class SvgViewHelper extends AbstractTagBasedViewHelper
 
     public function __construct(AssetCollector $assetCollector)
     {
+        parent::__construct();
         $this->assetCollector = $assetCollector;
     }
 


### PR DESCRIPTION
With new cms-composer-installers we can no longer use paths like /typo3conf/ext/ in our CSS-Files in urls (e.g. for background-images) and therefore we have to change the paths to relative paths. This PR resolves the relative paths in the CSS-File for inline style tag.