### PR TITLE
[BUGFIX] move assetcollector cache to INTincScript_ext

### DIFF
--- a/Tests/Functional/Frontend/Fixtures/InlineCssWithUncachedElement.csv
+++ b/Tests/Functional/Frontend/Fixtures/InlineCssWithUncachedElement.csv
@@ -1,0 +1,13 @@
+"pages"
+,"uid","pid","title","slug"
+,1,0,"root","/"
+"sys_template"
+,"uid","pid","root","config"
+,1,1,1,"page = PAGE
+page.10 = FLUIDTEMPLATE
+page.10.templateRootPaths.10 = EXT:assetcollector/Tests/Functional/Frontend/Fixtures/Templates
+page.10.templateName = InlineCss.html
+page.20 = COA_INT
+page.20.10 = TEXT
+page.20.10.value = bar
+"

--- a/Tests/Functional/Frontend/InlineCssWithUncachedElementTest.php
+++ b/Tests/Functional/Frontend/InlineCssWithUncachedElementTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace B13\Assetcollector\Tests\Functional\Functional;
+
+/*
+ * This file is part of TYPO3 CMS-based extension "assetcollector" by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+class InlineCssWithUncachedElementTest extends FunctionalTestCase
+{
+    protected array $testExtensionsToLoad = ['typo3conf/ext/assetcollector'];
+    protected array $coreExtensionsToLoad = ['core', 'frontend'];
+    protected array $pathsToLinkInTestInstance = ['typo3conf/ext/assetcollector/Build/sites' => 'typo3conf/sites'];
+
+    protected array $configurationToUseInTestInstance = [
+        'SYS' => [
+            'caching' => [
+                'cacheConfigurations' => [
+                    'pages' => [
+                        'backend' => \TYPO3\CMS\Core\Cache\Backend\Typo3DatabaseBackend::class,
+                        'options' => ['compression' => 0],
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+    /**
+     * @test
+     */
+    public function scriptTagForInlineCssIsRenderedUncached(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/InlineCssWithUncachedElement.csv');
+        $response = $this->executeFrontendSubRequest(new InternalRequest('http://localhost/'));
+        $expected = '<style class="tx_assetcollector">h1{color:red;}';
+        $body = (string)$response->getBody();
+        self::assertStringContainsString($expected, $body);
+        // cached
+        $response = $this->executeFrontendSubRequest(new InternalRequest('http://localhost/'));
+        $body = (string)$response->getBody();
+        self::assertStringContainsString($expected, $body);
+    }
+}


### PR DESCRIPTION
in TYPO3 v13 the TypoScriptController config array is no longer stored in the cache, therefore we moved the assetcollector cache to the INTincScript_ext Cache Data