### PR TITLE
[BUGFIX] cached svg assets with no body tag template

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         run: composer validate
 
       - name: Cache dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.composer/cache
           key: dependencies-composer-${{ hashFiles('composer.json') }}

--- a/Classes/Listener/AfterCacheableContentIsGenerated.php
+++ b/Classes/Listener/AfterCacheableContentIsGenerated.php
@@ -31,10 +31,16 @@ class AfterCacheableContentIsGenerated
     {
         $frontendController = $event->getController();
         $this->assetRenderer->collectInlineAssets([], $frontendController);
-        $event->getController()->content = str_ireplace(
-            '</body>',
-            $this->assetCollector->buildInlineXmlTag() . '</body>',
-            $event->getController()->content
-        );
+        $content = $event->getController()->content;
+        if (str_contains($content, '</body>')) {
+            $content = str_ireplace(
+                '</body>',
+                $this->assetCollector->buildInlineXmlTag() . '</body>',
+                $content
+            );
+        } else {
+            $content = $content . $this->assetCollector->buildInlineXmlTag();
+        }
+        $event->getController()->content = $content;
     }
 }

--- a/Tests/Functional/Frontend/Fixtures/SvgViewHelperWithNoBodyTag.csv
+++ b/Tests/Functional/Frontend/Fixtures/SvgViewHelperWithNoBodyTag.csv
@@ -1,0 +1,12 @@
+"pages"
+,"uid","pid","title","slug"
+,1,0,"root","/"
+"sys_template"
+,"uid","pid","root","config"
+,1,1,1,"page = PAGE
+page.config.disableAllHeaderCode = 1
+page.10 = FLUIDTEMPLATE
+page.10.templateRootPaths.10 = EXT:assetcollector/Tests/Functional/Frontend/Fixtures/Templates
+page.10.templateName = SvgViewHelper.html
+plugin.tx_assetcollector.icons.download = EXT:assetcollector/Resources/Public/Icons/Extension.svg
+"

--- a/Tests/Functional/Frontend/SvgViewHelperTest.php
+++ b/Tests/Functional/Frontend/SvgViewHelperTest.php
@@ -34,4 +34,20 @@ class SvgViewHelperTest extends FunctionalTestCase
         $expected = '<rect y="0.3" class="st0" width="256" height="256"></rect>';
         self::assertStringContainsString($expected, $body);
     }
+
+    /**
+     * @test
+     */
+    public function scriptTagForInlineCssIsRenderedWithNoBodyTag(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/SvgViewHelperWithNoBodyTag.csv');
+        $response = $this->executeFrontendSubRequest(new InternalRequest('http://localhost/'));
+        $expected = '<svg><use xlink:href="#icon-Extension"></use></svg>';
+        $body = (string)$response->getBody();
+        self::assertStringContainsString($expected, $body);
+        $expected = '<svg class="tx_assetcollector"';
+        self::assertStringContainsString($expected, $body);
+        $expected = '<rect y="0.3" class="st0" width="256" height="256"></rect>';
+        self::assertStringContainsString($expected, $body);
+    }
 }


### PR DESCRIPTION
when page content has no body tag simple append
inline SVG XML Tag to content.
s. also https://github.com/b13/assetcollector/blob/ff769caca06045e163d7881886e0d9babd6f1a97/Classes/Middleware/InlineSvgInjector.php#L46