### PR TITLE
[BUGFIX] assure xml inline tag is rendered only once

### DIFF
--- a/Classes/Listener/AfterCacheableContentIsGenerated.php
+++ b/Classes/Listener/AfterCacheableContentIsGenerated.php
@@ -31,16 +31,5 @@ class AfterCacheableContentIsGenerated
     {
         $frontendController = $event->getController();
         $this->assetRenderer->collectInlineAssets([], $frontendController);
-        $content = $event->getController()->content;
-        if (str_contains($content, '</body>')) {
-            $content = str_ireplace(
-                '</body>',
-                $this->assetCollector->buildInlineXmlTag() . '</body>',
-                $content
-            );
-        } else {
-            $content = $content . $this->assetCollector->buildInlineXmlTag();
-        }
-        $event->getController()->content = $content;
     }
 }

--- a/Tests/Functional/Frontend/Fixtures/SvgViewHelperMixed.csv
+++ b/Tests/Functional/Frontend/Fixtures/SvgViewHelperMixed.csv
@@ -1,0 +1,16 @@
+"pages"
+,"uid","pid","title","slug"
+,1,0,"root","/"
+"sys_template"
+,"uid","pid","root","config"
+,1,1,1,"page = PAGE
+page.10 = COA_INT
+page.10.10 = FLUIDTEMPLATE
+page.10.10.templateRootPaths.10 = EXT:assetcollector/Tests/Functional/Frontend/Fixtures/Templates
+page.10.10.templateName = SvgViewHelper.html
+plugin.tx_assetcollector.icons.download = EXT:assetcollector/Resources/Public/Icons/Extension.svg
+page.20 = COA
+page.20.10 = FLUIDTEMPLATE
+page.20.10.templateRootPaths.10 = EXT:assetcollector/Tests/Functional/Frontend/Fixtures/Templates
+page.20.10.templateName = SvgViewHelper.html
+"

--- a/Tests/Functional/Frontend/SvgViewHelperCachedTest.php
+++ b/Tests/Functional/Frontend/SvgViewHelperCachedTest.php
@@ -66,4 +66,22 @@ class SvgViewHelperCachedTest extends FunctionalTestCase
         $bodyCached = (string)$response->getBody();
         self::assertSame($bodyUncached, $bodyCached);
     }
+
+    /**
+     * @test
+     */
+    public function scriptTagForInlineCssIsRenderedForCachedAndIntContentMixed(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/SvgViewHelperMixed.csv');
+        $response = $this->executeFrontendSubRequest(new InternalRequest('http://localhost/'));
+        $expected = '<svg class="tx_assetcollector"';
+        $notExected = '</svg><svg class="tx_assetcollector"';
+        $bodyUncached = (string)$response->getBody();
+        self::assertStringContainsString($expected, $bodyUncached);
+        self::assertStringNotContainsString($notExected, $bodyUncached);
+        // cached
+        $response = $this->executeFrontendSubRequest(new InternalRequest('http://localhost/'));
+        $bodyCached = (string)$response->getBody();
+        self::assertSame($bodyUncached, $bodyCached);
+    }
 }


### PR DESCRIPTION
having cachend and uncached content in one request leads to render the xml inline tag twice, once in EventListener and once in Request Middleware.
This patch removes rendering of xml inline tag in EventListener and use the correct cache from frontendController for merging cached xml files