### PR TITLE
[FEATURE] provide an event before data are added to cache

### DIFF
--- a/Classes/Event/BeforeDataAreAddedToCacheEvent.php
+++ b/Classes/Event/BeforeDataAreAddedToCacheEvent.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace B13\Assetcollector\Event;
+
+/*
+ * This file is part of TYPO3 CMS-based extension "assetcollector" by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+use Psr\Http\Message\RequestInterface;
+
+final class BeforeDataAreAddedToCacheEvent
+{
+    public function __construct(
+        public readonly RequestInterface $request,
+        public array $cacheTags,
+    ) {
+    }
+}

--- a/Classes/Hooks/AssetRenderer.php
+++ b/Classes/Hooks/AssetRenderer.php
@@ -13,8 +13,11 @@ namespace B13\Assetcollector\Hooks;
  */
 
 use B13\Assetcollector\AssetCollector;
+use B13\Assetcollector\Event\BeforeDataAreAddedToCacheEvent;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use TYPO3\CMS\Core\Cache\CacheDataCollector;
 use TYPO3\CMS\Core\Cache\CacheTag;
 use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
@@ -41,8 +44,12 @@ use TYPO3\CMS\Core\Page\PageRenderer;
 #[Autoconfigure(public: true)]
 class AssetRenderer
 {
-    public function __construct(private readonly FrontendInterface $cache, private readonly AssetCollector $assetCollector)
-    {
+    public function __construct(
+        #[Autowire(service: 'cache.tx_assetcollector')]
+        private readonly FrontendInterface $cache,
+        private readonly AssetCollector $assetCollector,
+        private readonly EventDispatcherInterface $eventDispatcher
+    ) {
     }
 
     /**
@@ -151,6 +158,9 @@ class AssetRenderer
         $identifier = $cacheDataCollector->getPageCacheIdentifier();
         $cacheTags = array_map(fn (CacheTag $cacheTag) => $cacheTag->name, $cacheDataCollector->getCacheTags());
         $cacheTimeout = $cacheDataCollector->resolveLifetime();
+        $beforeDataAreAddedToCacheEvent = new BeforeDataAreAddedToCacheEvent($request, $cacheTags);
+        $this->eventDispatcher->dispatch($beforeDataAreAddedToCacheEvent);
+        $cacheTags = $beforeDataAreAddedToCacheEvent->cacheTags;
         $this->cache->set($identifier, $data, $cacheTags, $cacheTimeout);
     }
 

--- a/Classes/Middleware/InlineSvgInjector.php
+++ b/Classes/Middleware/InlineSvgInjector.php
@@ -17,6 +17,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use TYPO3\CMS\Core\Cache\CacheDataCollector;
 use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
 use TYPO3\CMS\Core\Http\NullResponse;
@@ -27,8 +28,11 @@ use TYPO3\CMS\Core\Http\Stream;
  */
 class InlineSvgInjector implements MiddlewareInterface
 {
-    public function __construct(private readonly FrontendInterface $cache, private readonly AssetCollector $assetCollector)
-    {
+    public function __construct(
+        #[Autowire(service: 'cache.tx_assetcollector')]
+        private readonly FrontendInterface $cache,
+        private readonly AssetCollector $assetCollector
+    ) {
     }
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -11,9 +11,4 @@ services:
     class: TYPO3\CMS\Core\Cache\Frontend\FrontendInterface
     factory: ['@TYPO3\CMS\Core\Cache\CacheManager', 'getCache']
     arguments: ['tx_assetcollector']
-  B13\Assetcollector\Middleware\InlineSvgInjector:
-    arguments:
-      $cache: '@cache.tx_assetcollector'
-  B13\Assetcollector\Hooks\AssetRenderer:
-    arguments:
-      $cache: '@cache.tx_assetcollector'
+


### PR DESCRIPTION
this event allows you to modify the cacheTags.
can be usefull if page-cache has a lot of tags (e.g. EXT:menus is installed) and you want to reduce the cacheTags to the page cache tag 'pageId_<id>'

additional: move Cache Service Configuration to PHP Attributes